### PR TITLE
Make changes to the task to allow for central scheduling

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -382,6 +382,29 @@ release
   "cdh4".
 
 
+[k8s]
+-------
+
+Parameters controlling Kubernetes Job Tasks
+
+auth_method
+  Authorization method to access the cluster.
+  Options are "kubeconfig_" or "service-account_"
+
+kubeconfig_path
+  Path to kubeconfig file, for cluster authentication.
+  It defaults to ``~/.kube/config``, which is the default location when
+  using minikube_.
+  When auth_method is "service-account" this property is ignored.
+
+max_retrials
+  Maximum number of retrials in case of job failure.
+
+.. _service-account: http://kubernetes.io/docs/user-guide/kubeconfig-file
+.. _kubeconfig: http://kubernetes.io/docs/user-guide/service-accounts
+.. _minikube: http://kubernetes.io/docs/getting-started-guides/minikube
+
+
 [mysql]
 -------
 

--- a/examples/kubernetes_job.py
+++ b/examples/kubernetes_job.py
@@ -14,9 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+Example Kubernetes Job Task.
+
+Requires:
+
+- pykube: ``pip install pykube``
+- A local minikube custer up and running: http://kubernetes.io/docs/getting-started-guides/minikube/
+
+**WARNING**: For Python versions < 3.5 the kubeconfing file must point to a Kubernetes API
+hostname, and NOT to an IP address.
+
+You can run this code example like this:
+
+    .. code:: console
+        $ luigi --module examples.kubernetes_job PerlPi --local-scheduler
+
+Running this code will create a pi-luigi-uuid kubernetes job within the cluster
+pointed to by the default context in "~/.kube/config".
+
+When working within a kubernetes cluster, set auth_method = "ServiceAccount" to
+access the local cluster.
+"""
 
 import luigi
 from luigi.contrib.k8s_job import KubernetesJobTask
+
 
 class PerlPi(KubernetesJobTask):
 
@@ -30,5 +53,6 @@ class PerlPi(KubernetesJobTask):
         }]
     }
 
-if __name__ == "__main__":
-    luigi.run(['PerlPi', '--local-scheduler'])
+    def output(self):
+        target = "/tmp/PerlPi"
+        return luigi.LocalTarget(target)

--- a/examples/kubernetes_job.py
+++ b/examples/kubernetes_job.py
@@ -22,7 +22,7 @@ Requires:
 - pykube: ``pip install pykube``
 - A local minikube custer up and running: http://kubernetes.io/docs/getting-started-guides/minikube/
 
-**WARNING**: For Python versions < 3.5 the kubeconfing file must point to a Kubernetes API
+**WARNING**: For Python versions < 3.5 the kubeconfig file must point to a Kubernetes API
 hostname, and NOT to an IP address.
 
 You can run this code example like this:
@@ -33,10 +33,11 @@ You can run this code example like this:
 Running this code will create a pi-luigi-uuid kubernetes job within the cluster
 pointed to by the default context in "~/.kube/config".
 
-When working within a kubernetes cluster, set auth_method = "ServiceAccount" to
+If running within a kubernetes cluster, set auth_method = "service-account" to
 access the local cluster.
 """
 
+import os
 import luigi
 from luigi.contrib.k8s_job import KubernetesJobTask
 
@@ -53,6 +54,10 @@ class PerlPi(KubernetesJobTask):
         }]
     }
 
+    def signal_complete(self):
+        with self.output().open('w') as output:
+            output.write('')
+
     def output(self):
-        target = "/tmp/PerlPi"
+        target = os.path.join("/tmp", "PerlPi")
         return luigi.LocalTarget(target)

--- a/examples/kubernetes_job.py
+++ b/examples/kubernetes_job.py
@@ -37,8 +37,8 @@ If running within a kubernetes cluster, set auth_method = "service-account" to
 access the local cluster.
 """
 
-import os
-import luigi
+# import os
+# import luigi
 from luigi.contrib.k8s_job import KubernetesJobTask
 
 
@@ -54,10 +54,12 @@ class PerlPi(KubernetesJobTask):
         }]
     }
 
-    def signal_complete(self):
-        with self.output().open('w') as output:
-            output.write('')
-
-    def output(self):
-        target = os.path.join("/tmp", "PerlPi")
-        return luigi.LocalTarget(target)
+    # defining the two functions below allows for dependency checking,
+    # but isn't a requirement
+    # def signal_complete(self):
+    #     with self.output().open('w') as output:
+    #         output.write('')
+    #
+    # def output(self):
+    #     target = os.path.join("/tmp", "PerlPi")
+    #     return luigi.LocalTarget(target)

--- a/luigi/contrib/k8s_job.py
+++ b/luigi/contrib/k8s_job.py
@@ -105,6 +105,15 @@ class KubernetesJobTask(luigi.Task):
         raise NotImplementedError("subclass must define name")
 
     @property
+    def labels(self):
+        """
+        Return custom labels for kubernetes job.
+        example::
+            ``{"run_dt": datetime.date.today().strftime('%F')}``
+        """
+        return {}
+
+    @property
     def spec_schema(self):
         """
         Kubernetes Job spec schema in JSON format, example::
@@ -207,6 +216,7 @@ class KubernetesJobTask(luigi.Task):
                 }
             }
         }
+        job_json['metadata']['labels'].update(self.labels)
         job = Job(self.__kube_api, job_json)
         job.create()
         # Track the Job (wait while active)

--- a/luigi/contrib/k8s_job.py
+++ b/luigi/contrib/k8s_job.py
@@ -169,7 +169,7 @@ class KubernetesJobTask(luigi.Task):
          with self.output().open('w') as output_file:
              output_file.write('')
         """
-        raise NotImplementedError("subclass must define signal_completion")
+        pass
 
     def __get_job_status(self):
         """Return the Kubernetes job status"""
@@ -224,6 +224,8 @@ class KubernetesJobTask(luigi.Task):
         self.__track_job()
 
     def output(self):
-        """An output target is necessary for checking job completion. example::
+        """An output target is necessary for checking job completion unless
+        alternative complete method is defined.
+         example::
         ``return luigi.LocalTarget(os.path.join('/tmp', 'example'))``"""
-        raise NotImplementedError("Subclass must define output")
+        pass


### PR DESCRIPTION
## Description
I implemented the changes which were requested in the original pull request, along with the changes which should make it easier for central scheduling.

These are the big changes:
#### Code
* output is now required of k8s job tasks, as this allows checking for job completion
* __init__ has been changed to _init_k8s, as the central scheduler was having trouble invoking the task.
* signal_complete is now required (mainly to give a configurable output location rather than just touching a local file).
#### Configuration Information
* Add information about the new configuration settings for k8s to `configuration.rst` in the docs
#### Tests/Examples
* Update tests and examples to implement new requirements and check behavior. 



## Motivation and Context
Without having an output from the kubernetes job, there's no way to check job completion. This means that the job wouldn't work in a pipeline. 

## Have you tested this? If so, how?
Tests have been updated to check writing of a file on successful job completion
