### PR TITLE
Fix spec_schema call to allow definition as method

### DIFF
--- a/examples/kubernetes.py
+++ b/examples/kubernetes.py
@@ -46,13 +46,14 @@ class PerlPi(KubernetesJobTask):
 
     name = "pi"
     max_retrials = 3
-    spec_schema = {
-        "containers": [{
-            "name": "pi",
-            "image": "perl",
-            "command": ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-        }]
-    }
+    def spec_schema(self):
+        return {
+            "containers": [{
+                "name": "pi",
+                "image": "perl",
+                "command": ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+            }]
+        }
 
     # defining the two functions below allows for dependency checking,
     # but isn't a requirement

--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -76,8 +76,8 @@ class KubernetesJobTask(luigi.Task):
             raise ValueError("Illegal auth_method")
         self.job_uuid = str(uuid.uuid4().hex)
         self.uu_name = self.name + "-luigi-" + self.job_uuid
-        if ("restartPolicy" not in self.spec_schema):
-            self.spec_schema["restartPolicy"] = "Never"
+        if ("restartPolicy" not in self.spec_schema()):
+            self.spec_schema()["restartPolicy"] = "Never"
 
     @property
     def auth_method(self):
@@ -224,7 +224,7 @@ class KubernetesJobTask(luigi.Task):
                     "metadata": {
                         "name": self.uu_name
                     },
-                    "spec": self.spec_schema
+                    "spec": self.spec_schema()
                 }
             }
         }

--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -76,8 +76,9 @@ class KubernetesJobTask(luigi.Task):
             raise ValueError("Illegal auth_method")
         self.job_uuid = str(uuid.uuid4().hex)
         self.uu_name = self.name + "-luigi-" + self.job_uuid
-        if ("restartPolicy" not in self.spec_schema()):
-            self.spec_schema()["restartPolicy"] = "Never"
+        self.__user_spec_schema = self.spec_schema()
+        if ("restartPolicy" not in self.__user_spec_schema):
+            self.__user_spec_schema["restartPolicy"] = "Never"
 
     @property
     def auth_method(self):
@@ -224,7 +225,7 @@ class KubernetesJobTask(luigi.Task):
                     "metadata": {
                         "name": self.uu_name
                     },
-                    "spec": self.spec_schema()
+                    "spec": self.__user_spec_schema
                 }
             }
         }

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -48,25 +48,27 @@ except ImportError:
 
 class SuccessJob(KubernetesJobTask):
     name = "success"
-    spec_schema = {
-        "containers": [{
-            "name": "hello",
-            "image": "alpine:3.4",
-            "command": ["echo",  "Hello World!"]
-        }]
-    }
+    def spec_schema(self):
+        return {
+            "containers": [{
+                "name": "hello",
+                "image": "alpine:3.4",
+                "command": ["echo",  "Hello World!"]
+            }]
+        }
 
 
 class FailJob(KubernetesJobTask):
     name = "fail"
     max_retrials = 3
-    spec_schema = {
-        "containers": [{
-            "name": "fail",
-            "image": "alpine:3.4",
-            "command": ["You",  "Shall", "Not", "Pass"]
-        }]
-    }
+    def spec_schema(self):
+        return {
+            "containers": [{
+                "name": "fail",
+                "image": "alpine:3.4",
+                "command": ["You",  "Shall", "Not", "Pass"]
+            }]
+        }
 
 
 class TestK8STask(unittest.TestCase):


### PR DESCRIPTION
## Description
In this PR I change the way spec_schema is called in order to allow its definition as a method. This is important as the specification schema sometimes needs to be rendered from variables that are available from `self`. 

For an example please refer to: https://github.com/phnmnl/jupyter-demo/blob/master/preprocessing_workflow.py

## Motivation and Context
It allows the specification schema to be rendered from variables that are available from `self`.

## Have you tested this? If so, how?
See the unit tests.
